### PR TITLE
Tests for 432470 - Lock transitive dependency and Exclude artifact

### DIFF
--- a/org.eclipse.m2e.tests/projects/refactoring/exclude/noParentBadFormat/pom.xml
+++ b/org.eclipse.m2e.tests/projects/refactoring/exclude/noParentBadFormat/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2011 Sonatype, Inc.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>test.refactoring.exclude</groupId>
+	<artifactId>noParentBadFormat</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+
+	<packaging>pom</packaging>
+	
+	<dependencies>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>  
+			</exclusions>
+		</dependency>
+	</dependencies>
+</project>


### PR DESCRIPTION
actions miss changes on certain poms.

Signed-off-by: Anton Tanasenko atg.sleepless@gmail.com
