### PR TITLE
436929 - Changes in imported dependencyManagement poms do not cause

### DIFF
--- a/org.eclipse.m2e.tests/projects/436929_import_refresh/deps/pom.xml
+++ b/org.eclipse.m2e.tests/projects/436929_import_refresh/deps/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.m2e.test</groupId>
+    <artifactId>m2e-test-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>436929-deps</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>436929-p1</artifactId>
+        <version>2.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
+</project>

--- a/org.eclipse.m2e.tests/projects/436929_import_refresh/deps/pom_modified.xml
+++ b/org.eclipse.m2e.tests/projects/436929_import_refresh/deps/pom_modified.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.m2e.test</groupId>
+    <artifactId>m2e-test-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>436929-deps</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>436929-p1</artifactId>
+        <version>1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
+</project>

--- a/org.eclipse.m2e.tests/projects/436929_import_refresh/deps2/pom.xml
+++ b/org.eclipse.m2e.tests/projects/436929_import_refresh/deps2/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.m2e.test</groupId>
+    <artifactId>m2e-test-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>436929-deps2</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  
+</project>

--- a/org.eclipse.m2e.tests/projects/436929_import_refresh/p1/pom.xml
+++ b/org.eclipse.m2e.tests/projects/436929_import_refresh/p1/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>436929-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>436929-p1</artifactId>
+  <version>1.0</version>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>436929-deps3</artifactId>
+        <version>1.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/org.eclipse.m2e.tests/projects/436929_import_refresh/p2/pom.xml
+++ b/org.eclipse.m2e.tests/projects/436929_import_refresh/p2/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>436929-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>436929-p2</artifactId>
+  <version>1.0</version>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>436929-deps</artifactId>
+        <version>1.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>436929-deps3</artifactId>
+        <version>1.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
+  <dependencies>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>436929-p1</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/org.eclipse.m2e.tests/repositories/testrepo/test/436929-deps3/1.0/436929-deps3-1.0.pom
+++ b/org.eclipse.m2e.tests/repositories/testrepo/test/436929-deps3/1.0/436929-deps3-1.0.pom
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.m2e.test</groupId>
+    <artifactId>m2e-test-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>436929-deps3</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  
+</project>

--- a/org.eclipse.m2e.tests/repositories/testrepo/test/436929-parent/1.0/436929-parent-1.0.pom
+++ b/org.eclipse.m2e.tests/repositories/testrepo/test/436929-parent/1.0/436929-parent-1.0.pom
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.m2e.test</groupId>
+    <artifactId>m2e-test-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>test</groupId>
+  <artifactId>436929-parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>test</groupId>
+        <artifactId>436929-deps2</artifactId>
+        <version>1.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
+</project>


### PR DESCRIPTION
436929 - Changes in imported dependencyManagement poms do not cause refresh in dependent projects

Signed-off-by: Anton Tanasenko atg.sleepless@gmail.com
