### PR TITLE
486739: testcase for updating exported classpath container

### DIFF
--- a/org.eclipse.m2e.tests/projects/486739_exportedContainer/pom.xml
+++ b/org.eclipse.m2e.tests/projects/486739_exportedContainer/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.m2e.test</groupId>
+    <artifactId>m2e-test-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>486739_exportedContainer</groupId>
+  <artifactId>project</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+<dependencyManagement>
+	<dependencies>
+		<dependency>
+		   <groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-surefire-plugin</artifactId>
+			<version>2.4.3</version>
+		</dependency>
+	</dependencies>
+</dependencyManagement>
+</project>


### PR DESCRIPTION
Adds a testcase for https://bugs.eclipse.org/bugs/show_bug.cgi?id=486739

Change-Id: Ic42d0fab3c91f7a43368b24097a16ca6717bd62b
Signed-off-by: Carsten Pfeiffer <carsten.pfeiffer@gebit.de>