### PR TITLE
525880: add test for preserving access rules

### DIFF
--- a/org.eclipse.m2e.tests/projects/525880_java_pom_with_access_rules/pom.xml
+++ b/org.eclipse.m2e.tests/projects/525880_java_pom_with_access_rules/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.m2e.test</groupId>
+    <artifactId>m2e-test-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>525880_java_pom_with_access_rules</groupId>
+  <artifactId>project</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+</project>


### PR DESCRIPTION
Add test to verify that access rules are preserved on the Maven
classpath container when a Java project is updated.

Gerrit-Url: https://git.eclipse.org/r/#/c/106604/
Task-Url: https://bugs.eclipse.org/bugs/show_bug.cgi?id=525880
Signed-off-by: David Green <david.green@tasktop.com>