### PR TITLE
Bug 387736 - NPE thrown when no "action" supplied in lifecycle-mapping pluginExecution

### DIFF
--- a/org.eclipse.m2e.tests/projects/lifecyclemapping/387736/pom.xml
+++ b/org.eclipse.m2e.tests/projects/lifecyclemapping/387736/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.m2e.test</groupId>
+	<artifactId>387736</artifactId>
+	<version>1.0.0</version>
+	
+	<packaging>jar</packaging>
+	<name>testNoAction</name>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.m2e.test.lifecyclemapping</groupId>
+				<artifactId>test-buildhelper-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>publish</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.eclipse.m2e.test.lifecyclemapping</groupId>
+										<artifactId>test-buildhelper-plugin</artifactId>
+										<versionRange>
+											[1.0,)
+										</versionRange>
+										<goals>
+											<goal>publish</goal>
+										</goals>
+									</pluginExecutionFilter>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/lifecycle/LifecycleMappingTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/lifecycle/LifecycleMappingTest.java
@@ -865,4 +865,18 @@ public class LifecycleMappingTest extends AbstractLifecycleMappingTest {
     assertEquals(actionDom, metadata.getActionDom());
 
   }
+
+  public void test387736_missingAction() throws Exception {
+    IMavenProjectFacade facade = importMavenProject("projects/lifecyclemapping/387736", "pom.xml");
+    assertNotNull("Expected not null MavenProjectFacade", facade);
+    IProject project = facade.getProject();
+    assertNotNull("Expected not null project", project);
+
+    // the mapping is ignored because of the missing action
+    List<MojoExecutionKey> notCoveredMojoExecutions = getNotCoveredMojoExecutions(facade);
+    assertEquals(notCoveredMojoExecutions.toString(), 1, notCoveredMojoExecutions.size());
+    assertEquals(
+        "org.eclipse.m2e.test.lifecyclemapping:test-buildhelper-plugin:1.0.0:publish (execution: add-source, phase: generate-sources)",
+        notCoveredMojoExecutions.get(0).toString());
+  }
 }


### PR DESCRIPTION
Test for the patch in https://git.eclipse.org/r/#/c/123090/