### PR TITLE
Avoid referencing org.eclipse.equinox.ds

### DIFF
--- a/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.tests;singleton:=true
 Bundle-Version: 1.10.0.qualifier
+Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
 Require-Bundle: org.eclipse.core.externaltools,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
@@ -25,7 +26,6 @@ Require-Bundle: org.eclipse.core.externaltools,
  org.eclipse.equinox.p2.discovery,
  org.eclipse.equinox.p2.discovery.compatibility,
  org.eclipse.equinox.p2.ui.discovery,
- org.eclipse.equinox.ds,
  org.eclipse.equinox.event,
  org.eclipse.m2e.core.ui,
  org.eclipse.m2e.scm,


### PR DESCRIPTION
This bundle was removed in 4.10 and some recommandations have
been emitted to replace it.

Signed-off-by: Mickael Istria <mistria@redhat.com>