### PR TITLE
m2e-core issue #271 : Fix integration-tests failing on Windows

### DIFF
--- a/org.eclipse.m2e.editor.xml.tests/src/org/eclipse/m2e/editor/xml/PomEditsTest.java
+++ b/org.eclipse.m2e.editor.xml.tests/src/org/eclipse/m2e/editor/xml/PomEditsTest.java
@@ -89,7 +89,7 @@ public class PomEditsTest extends AbstractMavenProjectTestCase {
   private String getContent(IFile file) throws Exception{
     IStructuredModel model = StructuredModelManager.getModelManager().getModelForRead(file);
     try {
-      return model.getStructuredDocument().get();
+      return model.getStructuredDocument().get().replaceAll("\\R", System.lineSeparator());
     } finally {
       model.releaseFromRead();
     }

--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/launch/MavenRuntimeClasspathProviderTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/launch/MavenRuntimeClasspathProviderTest.java
@@ -151,7 +151,7 @@ public class MavenRuntimeClasspathProviderTest extends AbstractMavenProjectTestC
     assertTrue(delta >= 0);
     for(int j = 0; j < expectedBinFolders.length; j++ ) {
       String location = classpathEntries[j + delta].getLocation();
-      String binFolder = expectedBinFolders[j];
+      String binFolder = expectedBinFolders[j].replace('/', File.separatorChar);
       assertTrue("got " + location + " but expected something ending with " + binFolder, location.endsWith(binFolder));
     }
   }


### PR DESCRIPTION
This PR fixes the m2e-core-tests that fail on windows only, which is part of https://github.com/eclipse-m2e/m2e-core/issues/271.

The test failures are connected to different file-separators and line-endings for windows and unix or the required administrator privileges to create symbolic-links.

In case of missing administrator privileges to create symbolic links, the error message was made more expressive to guide developers that they have to run the tests (respectively their IDE) with administrator privileges.