### PR TITLE
Unify and simplify plug-in meta-data

### DIFF
--- a/org.eclipse.m2e.editor.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.tests/META-INF/MANIFEST.MF
@@ -25,10 +25,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2e.core.ui,
  org.junit;bundle-version="4.0.0"
 Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
-Bundle-Name: %Bundle-Name
+Bundle-Name: M2E Maven POM File Editor Tests
 Bundle-Version: 1.16.0.qualifier
 MavenArtifact-ArtifactId: org.eclipse.m2e.test
-Bundle-Vendor: %Bundle-Vendor
+Bundle-Vendor: Eclipse.org - m2e
 Bundle-SymbolicName: org.eclipse.m2e.editor.tests;singleton:=true
 Bundle-ClassPath: .
 MavenArtifact-GroupId: org.eclipse.m2e

--- a/org.eclipse.m2e.editor.tests/OSGI-INF/l10n/bundle.properties
+++ b/org.eclipse.m2e.editor.tests/OSGI-INF/l10n/bundle.properties
@@ -1,3 +1,0 @@
-#Properties file for org.eclipse.m2e.editor.tests
-Bundle-Vendor = Eclipse m2e
-Bundle-Name = Maven Integration Tests Plug-in

--- a/org.eclipse.m2e.editor.tests/build.properties
+++ b/org.eclipse.m2e.editor.tests/build.properties
@@ -2,5 +2,4 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               about.html,\
-               OSGI-INF/
+               about.html

--- a/org.eclipse.m2e.editor.xml.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.xml.tests/META-INF/MANIFEST.MF
@@ -24,10 +24,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2e.core.ui;bundle-version="1.17.2",
  org.eclipse.equinox.event,
  org.eclipse.ui.workbench.texteditor
-Bundle-Name: %Bundle-Name
+Bundle-Name: M2E Maven POM File XML Editor Tests
 Bundle-Version: 1.17.2.qualifier
 MavenArtifact-ArtifactId: org.eclipse.m2e.editor.xml.tests
-Bundle-Vendor: %Bundle-Vendor
+Bundle-Vendor: Eclipse.org - m2e
 Bundle-SymbolicName: org.eclipse.m2e.editor.xml.tests;singleton:=true
 Bundle-ClassPath: .
 MavenArtifact-GroupId: org.eclipse.m2e

--- a/org.eclipse.m2e.editor.xml.tests/OSGI-INF/l10n/bundle.properties
+++ b/org.eclipse.m2e.editor.xml.tests/OSGI-INF/l10n/bundle.properties
@@ -1,3 +1,0 @@
-#Properties file for org.eclipse.m2e.editor.xml.tests
-Bundle-Vendor = Eclipse m2e
-Bundle-Name = Maven POM XML Editor Tests Plug-In

--- a/org.eclipse.m2e.editor.xml.tests/build.properties
+++ b/org.eclipse.m2e.editor.xml.tests/build.properties
@@ -13,7 +13,6 @@
 bin.includes = META-INF/,\
                .,\
                about.html,\
-               OSGI-INF/,\
                plugin.xml
 source.. = src/
 output.. = target/classes/

--- a/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %Bundle-Name
+Bundle-Name: M2E Tests
 Bundle-SymbolicName: org.eclipse.m2e.tests;singleton:=true
 Bundle-Version: 1.17.2.qualifier
 Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
@@ -40,7 +40,7 @@ Require-Bundle: org.eclipse.core.externaltools,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .
-Bundle-Vendor: %Bundle-Vendor
+Bundle-Vendor: Eclipse.org - m2e
 MavenArtifact-GroupId: org.eclipse.m2e
 MavenArtifact-ArtifactId: org.eclipse.m2e.test
 Export-Package: org.eclipse.m2e.tests,

--- a/org.eclipse.m2e.tests/OSGI-INF/l10n/bundle.properties
+++ b/org.eclipse.m2e.tests/OSGI-INF/l10n/bundle.properties
@@ -1,3 +1,0 @@
-#Properties file for org.eclipse.m2e.tests
-Bundle-Vendor = Eclipse m2e
-Bundle-Name = Maven Integration Tests Plug-in

--- a/org.eclipse.m2e.tests/build.properties
+++ b/org.eclipse.m2e.tests/build.properties
@@ -16,5 +16,4 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                archetype-catalog.xml,\
-               about.html,\
-               OSGI-INF/
+               about.html


### PR DESCRIPTION
Similar changes like in https://github.com/eclipse-m2e/m2e-core/pull/339 just for the m2e-core-tests plug-ins.

@mickaelistria can you please merge this?