### PR TITLE
Re-add Require-Bundle org.eclipse.m2e.maven.indexer

### DIFF
--- a/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Require-Bundle: org.eclipse.core.externaltools,
  org.eclipse.m2e.jdt,
  org.junit;bundle-version="4.11.0",
  org.eclipse.m2e.launching,
+ org.eclipse.m2e.maven.indexer,
  org.eclipse.m2e.tests.common,
  org.eclipse.equinox.p2.discovery,
  org.eclipse.equinox.p2.discovery.compatibility,
@@ -34,8 +35,7 @@ Require-Bundle: org.eclipse.core.externaltools,
  org.eclipse.m2e.editor.xml,
  org.eclipse.jdt.junit,
  org.eclipse.core.expressions,
- org.eclipse.m2e.profiles.core,
- org.eclipse.m2e.tests.common
+ org.eclipse.m2e.profiles.core
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .


### PR DESCRIPTION
This re-adds Require-Bundle `org.eclipse.m2e.maven.indexer` to `org.eclipse.m2e.tests` to fix failing tests at m2e-core.
Additionally it removes the duplicated entry `org.eclipse.m2e.tests.common`.

This is intended as a replacement for #136 until the Indexer is removed from M2E.
