### PR TITLE
Could org.eclipse.m2e.test.build:438454_guicescopes-plugin:1.0.0 drop off redundant dependencies?

### DIFF
--- a/org.eclipse.m2e.tests/repositories/testrepo-src/438454_guicescopes-plugin/pom.xml
+++ b/org.eclipse.m2e.tests/repositories/testrepo-src/438454_guicescopes-plugin/pom.xml
@@ -34,6 +34,28 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-model</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.plexus</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-artifact</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.eclipse.m2e.test.build:438454_guicescopes-plugin:1.0.0_** introduced **_16_** dependencies. However, among them, **_14_** libraries (**_87%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.apache.maven:maven-artifact:jar:3.2.2:compile
com.google.code.findbugs:jsr305:jar:1.3.9:compile
aopalliance:aopalliance:jar:1.0:compile
org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0:compile
com.google.guava:guava:jar:10.0.1:compile
javax.enterprise:cdi-api:jar:1.0:compile
org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.0.0.M5:compile
javax.inject:javax.inject:jar:1:compile
javax.annotation:jsr250-api:jar:1.0:compile
org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.0.0.M5:compile
org.apache.maven:maven-model:jar:3.2.2:compile
org.codehaus.plexus:plexus-utils:jar:3.0.17:compile
org.codehaus.plexus:plexus-classworlds:jar:2.5.1:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_com.google.guava:guava:jar:10.0.1:compile_** incorporates a medium-level vulnerability SNYK-JAVA-COMGOOGLEGUAVA-1015415. As such, I suggest a refactoring operation for **_org.eclipse.m2e.test.build:438454_guicescopes-plugin:1.0.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.eclipse.m2e.test.build:438454_guicescopes-plugin:1.0.0_**’s maven tests.

Best regards