### PR TITLE
Bump remaining Plug-ins to version 2.0.0 and remove dependency versions

### DIFF
--- a/org.eclipse.m2e.editor.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.editor.tests/META-INF/MANIFEST.MF
@@ -21,10 +21,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.event,
  org.eclipse.m2e.tests.common,
  org.eclipse.m2e.core.ui,
- org.junit;bundle-version="4.0.0"
+ org.junit
 Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
 Bundle-Name: M2E Maven POM File Editor Tests
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 MavenArtifact-ArtifactId: org.eclipse.m2e.test
 Bundle-Vendor: Eclipse.org - m2e
 Bundle-SymbolicName: org.eclipse.m2e.editor.tests;singleton:=true

--- a/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: M2E Tests
 Bundle-SymbolicName: org.eclipse.m2e.tests;singleton:=true
-Bundle-Version: 1.17.2.qualifier
+Bundle-Version: 2.0.0.qualifier
 Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
 Require-Bundle: org.eclipse.core.externaltools,
  org.eclipse.core.runtime,
@@ -13,13 +13,13 @@ Require-Bundle: org.eclipse.core.externaltools,
  org.eclipse.jface,
  org.eclipse.ui,
  org.eclipse.ui.console,
- org.eclipse.m2e.core;bundle-version="2.0.0",
- org.eclipse.m2e.editor;bundle-version="1.17.2",
+ org.eclipse.m2e.core,
+ org.eclipse.m2e.editor,
  org.eclipse.m2e.maven.runtime,
  org.eclipse.m2e.model.edit,
  org.eclipse.m2e.archetype.common,
  org.eclipse.m2e.jdt,
- org.junit;bundle-version="4.11.0",
+ org.junit,
  org.eclipse.m2e.launching,
  org.eclipse.m2e.tests.common,
  org.eclipse.equinox.p2.discovery,
@@ -33,7 +33,7 @@ Require-Bundle: org.eclipse.core.externaltools,
  org.eclipse.jdt.junit,
  org.eclipse.core.expressions,
  org.eclipse.m2e.profiles.core,
- org.eclipse.m2e.mavenarchiver;bundle-version="2.0.0"
+ org.eclipse.m2e.mavenarchiver
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .


### PR DESCRIPTION
For tests it is not crucial to have a version specified since the
available version are usually controlled by the workspace TP. So
specifying no version simplifies dependency updates.