### PR TITLE
Revert "Adapt MavenLaunchDelegateTest to not yet present console coloring"

### DIFF
--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/launch/MavenLaunchDelegateTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/launch/MavenLaunchDelegateTest.java
@@ -127,20 +127,20 @@ public class MavenLaunchDelegateTest {
     ILaunchConfiguration configuration = getLaunchConfiguration("projects/444262_settings");
     try {
       performDummyLaunch(configuration);
-      assertArrayEquals(new String[] {"-B", "-Dstyle.color=never"},
+      assertArrayEquals(new String[] {"-B", "-Dstyle.color=always"},
             runner.getConfiguration().getProgramArguments());
 
       // relative preference path to global settings is relative to eclipse home 
       mavenConfig.setGlobalSettingsFile("settings_empty.xml");
       performDummyLaunch(configuration);
       assertArrayEquals(
-          new String[] {"-B", "-Dstyle.color=never", "-gs", new File("settings_empty.xml").getAbsolutePath()},
+          new String[] {"-B", "-Dstyle.color=always", "-gs", new File("settings_empty.xml").getAbsolutePath()},
           runner.getConfiguration().getProgramArguments());
 
       // specifying -gs within goals overrides global settings from  configuration
       configuration.getAttributes().put(MavenLaunchConstants.ATTR_GOALS, "clean -gs other_settings.xml");
       performDummyLaunch(configuration);
-      assertArrayEquals(new String[] {"-B", "-Dstyle.color=never", "clean", "-gs", "other_settings.xml"},
+      assertArrayEquals(new String[] {"-B", "-Dstyle.color=always", "clean", "-gs", "other_settings.xml"},
           runner.getConfiguration().getProgramArguments());
 
     } finally {
@@ -155,12 +155,12 @@ public class MavenLaunchDelegateTest {
     try {
       mavenConfig.setUserSettingsFile(new File("settings_empty.xml").getAbsolutePath());
       performDummyLaunch(configuration);
-      assertArrayEquals(new String[] {"-B", "-Dstyle.color=never", "-s", mavenConfig.getUserSettingsFile()},
+      assertArrayEquals(new String[] {"-B", "-Dstyle.color=always", "-s", mavenConfig.getUserSettingsFile()},
           runner.getConfiguration().getProgramArguments());
 
       configuration.getAttributes().put(MavenLaunchConstants.ATTR_USER_SETTINGS, "settings.xml");
       performDummyLaunch(configuration);
-      assertArrayEquals(new String[] {"-B", "-Dstyle.color=never", "-s", "settings.xml"},
+      assertArrayEquals(new String[] {"-B", "-Dstyle.color=always", "-s", "settings.xml"},
           runner.getConfiguration().getProgramArguments());
     } finally {
       mavenConfig.setUserSettingsFile(null);


### PR DESCRIPTION
Now that we build against Eclipse 4.25(-I-builds) coloring is present in
the Eclipse-platform.

This reverts commit 8b36acbf4e4fa81de2b2fb0df607cddbc043f6b6.