### PR TITLE
Add CI verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: Continuous Integration
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+
+    steps:
+    - name: Checkout m2e
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: false
+        repository: 'eclipse-m2e/m2e-core'
+        ref: 'master'
+    - name: Checkout tests
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: false
+        repository: 'tesla/m2e-core-tests'
+        path: 'm2e-core-tests'
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        # re-cache on changes in the pom and target files
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Build m2e-core
+      uses: coactions/setup-xvfb@v1
+      with:
+       run: mvn clean verify -Pits -Dtycho.p2.baselineMode=ignore --batch-mode
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results-${{ matrix.os }}
+        if-no-files-found: error
+        path: |
+          ${{ github.workspace }}/**/target/surefire-reports/*.xml
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,15 @@
+name: Publish Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build Tests"]
+    types:
+      - completed
+
+jobs:
+    check:
+       uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/publishTestResults.yml@master
+
+
+
+


### PR DESCRIPTION
Currently one can only run the tests from the m2e repo, but this is quite inconvenient.

This adds a "reverse ci check" that allows adjusting tests (and probably merge) against the current m2e master, e.g. if one wants to adjust/optimize tests.