### PR TITLE
adjust the test so they are not prone to classpath ordering

### DIFF
--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/BuildPathManagerTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/BuildPathManagerTest.java
@@ -1245,23 +1245,22 @@ public class BuildPathManagerTest extends AbstractMavenProjectTestCase {
     IProject project = importProject("projects/MNGECLIPSE-2367_sourcesResourcesOverlap/project04/pom.xml");
     assertNoErrors(project);
 
-    IJavaProject javaProject = JavaCore.create(project);
-
-    IClasspathEntry[] rawClasspath = javaProject.getRawClasspath();
-
-    assertClasspath(new String[] {//
-        "/project04/src/main/java", //
-        "/project04/src/main_impl/java", //
-        "/project04/src/test/java", //
+    String srcJava = "/project04/src/main/java";
+    String srcImpl = "/project04/src/main_impl/java";
+    String srcTest = "/project04/src/test/java";
+    Map<String, IClasspathEntry> map = assertClasspath(project,
+        srcJava, //
+        srcImpl, //
+        srcTest, //
         "org.eclipse.jdt.launching.JRE_CONTAINER/.*", //
-        "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER", //
-    }, //
-        rawClasspath);
-    assertEquals(0, rawClasspath[0].getExclusionPatterns().length);
-    assertEquals(0, rawClasspath[1].getExclusionPatterns().length);
-    assertEquals(1, rawClasspath[1].getInclusionPatterns().length);
-    assertEquals("**/*.java", rawClasspath[1].getInclusionPatterns()[0].toString());
-    assertEquals(0, rawClasspath[2].getExclusionPatterns().length);
+        "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER" //
+    );
+
+    assertEquals(0, map.get(srcJava).getExclusionPatterns().length);
+    assertEquals(0, map.get(srcImpl).getExclusionPatterns().length);
+    assertEquals(1, map.get(srcImpl).getInclusionPatterns().length);
+    assertEquals("**/*.java", map.get(srcImpl).getInclusionPatterns()[0].toString());
+    assertEquals(0, map.get(srcTest).getExclusionPatterns().length);
   }
 
   @Test
@@ -1269,21 +1268,18 @@ public class BuildPathManagerTest extends AbstractMavenProjectTestCase {
     IProject project = importProject("projects/MNGECLIPSE-2367_sourcesResourcesOverlap/project05/pom.xml");
     assertNoErrors(project);
 
-    IJavaProject javaProject = JavaCore.create(project);
-
-    IClasspathEntry[] rawClasspath = javaProject.getRawClasspath();
-
-    assertClasspath(new String[] {//
+    String resourcePath = "/project05/src/main/resources";
+    IClasspathEntry entry = assertClasspath(project,
         "/project05/src/main/java", //
-        "/project05/src/main/resources", //
+        resourcePath, //
         "/project05/src/test/java", //
         "org.eclipse.jdt.launching.JRE_CONTAINER/.*", //
-        "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER", //
-    }, //
-        rawClasspath);
-    assertEquals(0, rawClasspath[1].getInclusionPatterns().length);
-    assertEquals(1, rawClasspath[1].getExclusionPatterns().length);
-    assertEquals("**", rawClasspath[1].getExclusionPatterns()[0].toString());
+        "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER" //
+    ).get(resourcePath);
+    assertNotNull(entry);
+    assertEquals(0, entry.getInclusionPatterns().length);
+    assertEquals(1, entry.getExclusionPatterns().length);
+    assertEquals("**", entry.getExclusionPatterns()[0].toString());
   }
 
   @Test
@@ -1297,14 +1293,8 @@ public class BuildPathManagerTest extends AbstractMavenProjectTestCase {
     // ideally we need to add a warning marker on the offending pom.xml element
     // https://issues.sonatype.org/browse/MNGECLIPSE-2433
 
-    IJavaProject javaProject = JavaCore.create(projects[1]);
-    IClasspathEntry[] cp = javaProject.getRawClasspath();
-
-    assertEquals(4, cp.length);
-    assertEquals("/project02/src/main/java", cp[0].getPath().toPortableString());
-    assertEquals("/project02/src/test/java", cp[1].getPath().toPortableString());
-    assertEquals("org.eclipse.jdt.launching.JRE_CONTAINER", cp[2].getPath().segment(0));
-    assertEquals("org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER", cp[3].getPath().segment(0));
+    ClasspathHelpers.assertClasspath(projects[1], "/project02/src/main/java", "/project02/src/test/java",
+        "org.eclipse.jdt.launching.JRE_CONTAINER.*", "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER");
   }
 
   @Test

--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/ProjectRegistryManagerTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/ProjectRegistryManagerTest.java
@@ -1208,8 +1208,7 @@ public class ProjectRegistryManagerTest extends AbstractMavenProjectTestCase {
       IJavaProject javaProject = JavaCore.create(project);
       assertHasMarker(project, IMavenConstants.MARKER_DEPENDENCY_ID, "Checksum validation failed");
 
-      IClasspathEntry[] cp;
-      cp = BuildPathManager.getMaven2ClasspathContainer(javaProject).getClasspathEntries();
+      IClasspathEntry[] cp = BuildPathManager.getMaven2ClasspathContainer(javaProject).getClasspathEntries();
       ClasspathHelpers.assertClasspath(new String[] {".*bad-checksum-0.0.1-SNAPSHOT.jar"}, cp);
 
       setChecksumPolicy(ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN);
@@ -1252,8 +1251,7 @@ public class ProjectRegistryManagerTest extends AbstractMavenProjectTestCase {
       IJavaProject javaProject = JavaCore.create(project);
       assertHasMarker(project, IMavenConstants.MARKER_DEPENDENCY_ID, "Checksum validation failed");
 
-      IClasspathEntry[] cp;
-      cp = BuildPathManager.getMaven2ClasspathContainer(javaProject).getClasspathEntries();
+      IClasspathEntry[] cp = BuildPathManager.getMaven2ClasspathContainer(javaProject).getClasspathEntries();
       ClasspathHelpers.assertClasspath(new String[] {".*bad-checksum-0.0.1-SNAPSHOT.jar"}, cp);
 
       //Override specific repo config

--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/jdt/JavaCodeGenerationProjectConfiguratorTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/jdt/JavaCodeGenerationProjectConfiguratorTest.java
@@ -15,16 +15,15 @@ package org.eclipse.m2e.tests.jdt;
 
 import static org.eclipse.m2e.tests.common.ClasspathHelpers.assertClasspath;
 import static org.eclipse.m2e.tests.common.ClasspathHelpers.getClasspathAttribute;
-import static org.eclipse.m2e.tests.common.ClasspathHelpers.getClasspathEntry;
 import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
 
 import org.junit.Test;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.JavaCore;
 
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
@@ -38,43 +37,40 @@ public class JavaCodeGenerationProjectConfiguratorTest extends AbstractMavenProj
         "projects/368333_missingGeneratedSourceFolders", new ResolverConfiguration());
     assertNoErrors(project);
 
-    IJavaProject javaProject = JavaCore.create(project);
-
-    assertClasspath(new String[] {//
-        "/368333_missingGeneratedSourceFolders/src/main/java", //
+    String srcMain = "/368333_missingGeneratedSourceFolders/src/main/java";
+    String srcGeneratedTest = "/368333_missingGeneratedSourceFolders/target/generated-sources/test";
+    Map<String, IClasspathEntry> map = assertClasspath(project,
+        srcMain, //
             "/368333_missingGeneratedSourceFolders/src/test/java", //
             "org.eclipse.jdt.launching.JRE_CONTAINER/.*", //
             "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER", //
-            "/368333_missingGeneratedSourceFolders/target/generated-sources/test",//
-        }, //
-        javaProject.getRawClasspath());
+        srcGeneratedTest);
 
-    assertClasspathAttribute(javaProject.getRawClasspath(), "/368333_missingGeneratedSourceFolders/src/main/java",
+    assertClasspathAttribute(map, srcMain,
         IClasspathAttribute.IGNORE_OPTIONAL_PROBLEMS, null);
-    assertClasspathAttribute(javaProject.getRawClasspath(),
-        "/368333_missingGeneratedSourceFolders/target/generated-sources/test",
+    assertClasspathAttribute(map,
+        srcGeneratedTest,
         IClasspathAttribute.IGNORE_OPTIONAL_PROBLEMS, "true");
 
     MavenPlugin.getProjectConfigurationManager().updateProjectConfiguration(project, monitor);
 
-    assertClasspath(new String[] {//
-        "/368333_missingGeneratedSourceFolders/src/main/java", //
+    map = assertClasspath(project,
+        srcMain, //
             "/368333_missingGeneratedSourceFolders/src/test/java", //
             "org.eclipse.jdt.launching.JRE_CONTAINER/.*", //
             "org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER", //
-            "/368333_missingGeneratedSourceFolders/target/generated-sources/test",//
-        }, //
-        javaProject.getRawClasspath());
+        srcGeneratedTest);
 
-    assertClasspathAttribute(javaProject.getRawClasspath(), "/368333_missingGeneratedSourceFolders/src/main/java",
+    assertClasspathAttribute(map, srcMain,
         IClasspathAttribute.IGNORE_OPTIONAL_PROBLEMS, null);
-    assertClasspathAttribute(javaProject.getRawClasspath(),
-        "/368333_missingGeneratedSourceFolders/target/generated-sources/test",
+    assertClasspathAttribute(map,
+        srcGeneratedTest,
         IClasspathAttribute.IGNORE_OPTIONAL_PROBLEMS, "true");
   }
 
-  private void assertClasspathAttribute(IClasspathEntry[] cp, String path, String name, String expectedValue) {
-    IClasspathAttribute attribute = getClasspathAttribute(getClasspathEntry(cp, path), name);
+  private void assertClasspathAttribute(Map<String, IClasspathEntry> map, String path, String name,
+      String expectedValue) {
+    IClasspathAttribute attribute = getClasspathAttribute(map.get(path), name);
     String value = attribute != null ? attribute.getValue() : null;
     assertEquals(expectedValue, value);
   }


### PR DESCRIPTION
This will not change anything in the test results but make the test more robust to changes in the classpath by accessing the values where possible by their name instead of their index.