### PR TITLE
Disable BuildPathManagerTest.test431080_flatDirectoryLayout() test

### DIFF
--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/BuildPathManagerTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/BuildPathManagerTest.java
@@ -1313,6 +1313,7 @@ public class BuildPathManagerTest extends AbstractMavenProjectTestCase {
   }
 
   @Test
+  @Ignore("See https://github.com/eclipse-m2e/m2e-core/issues/1362")
   public void test431080_flatDirectoryLayout() throws Exception {
     IProject project = importProject("projects/431080_flatDirectoryLayout/pom.xml");
     waitForJobsToComplete();


### PR DESCRIPTION
The test project currently not produce a useable layout but also don't fail / assert anything, therefore the test is disabled unless we found a better implementation see
https://github.com/eclipse-m2e/m2e-core/issues/1362