### PR TITLE
More updates to 1.8

### DIFF
--- a/org.eclipse.m2e.tests/projects/537851-test-jar-in-compile-scope/project-consuming-test-jar/pom.xml
+++ b/org.eclipse.m2e.tests/projects/537851-test-jar-in-compile-scope/project-consuming-test-jar/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -10,6 +11,20 @@
 
 	<artifactId>project-consuming-test-jar</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.13.0</version>
+					<configuration>
+						<release>11</release>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.m2e.test</groupId>

--- a/org.eclipse.m2e.tests/projects/537851-test-jar-in-compile-scope/test-jar/pom.xml
+++ b/org.eclipse.m2e.tests/projects/537851-test-jar-in-compile-scope/test-jar/pom.xml
@@ -27,6 +27,14 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+				<configuration>
+					<release>11</release>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/org.eclipse.m2e.tests/repositories/testrepo-src/m2e-test-parent/pom.xml
+++ b/org.eclipse.m2e.tests/repositories/testrepo-src/m2e-test-parent/pom.xml
@@ -28,10 +28,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.0.2</version>
+          <version>3.13.0</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>

--- a/org.eclipse.m2e.tests/repositories/testrepo/org/eclipse/m2e/test/m2e-test-parent/1.0.0/m2e-test-parent-1.0.0.pom
+++ b/org.eclipse.m2e.tests/repositories/testrepo/org/eclipse/m2e/test/m2e-test-parent/1.0.0/m2e-test-parent-1.0.0.pom
@@ -28,10 +28,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.0.2</version>
+          <version>3.13.0</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
As ECJ no longer supports older targets.