### PR TITLE
Increase timeout to wait for a job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         fetch-depth: 0
         submodules: false
         repository: 'eclipse-m2e/m2e-core'
-        ref: 'master'
+        ref: 'main'
     - name: Checkout tests
       uses: actions/checkout@v4
       with:
@@ -56,6 +56,7 @@ jobs:
        run: mvn clean verify -Pits -Dtycho.p2.baselineMode=warn --batch-mode
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: test-results-${{ matrix.os }}
         if-no-files-found: error

--- a/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/internal/wizard/MappingDiscoveryJobTest.java
+++ b/org.eclipse.m2e.tests/src/org/eclipse/m2e/tests/internal/wizard/MappingDiscoveryJobTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class MappingDiscoveryJobTest extends AbstractMavenProjectTestCase {
   private void checkOpensMappingDiscoveryWizard(IProject project, boolean expectedResult) throws Exception {
     discoveryJob = new MappingDiscoveryJobNoUI(Collections.singleton(project));
     discoveryJob.schedule();
-    JobHelpers.waitForJobs(job -> discoveryJob == job, 100);
+    JobHelpers.waitForJobs(job -> discoveryJob == job, (int) TimeUnit.SECONDS.toMillis(10));
     assertEquals("MappingDiscoveryJob was " + (expectedResult ? "" : "not ") + "supposed to open", expectedResult,
         discoveryJob.openedMappingWizard);
   }


### PR DESCRIPTION
The test often "randomly" fails waiting for the job, but using 100ms seems either a typo or way to short.

This now increases the timeout to 10 seconds, this will make the test slow in case of real failures but these should not happen anyways in the usual case. If the test still fails we need to further investigate whats going on.